### PR TITLE
Allows local components in Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.helio-ecosystem</groupId>
 	<artifactId>helio-blueprints</artifactId>
-	<version>0.4.6</version>
+	<version>0.4.7</version>
 	<name>Helio Blueprints</name>
 	<description>Dependency for developing new components for Helio</description>
 	<url>https://helio-ecosystem.github.io/helio-blueprints</url>

--- a/src/main/java/helio/blueprints/ComponentsLoader.java
+++ b/src/main/java/helio/blueprints/ComponentsLoader.java
@@ -5,6 +5,12 @@ import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.net.URLClassLoader;
 
+/**
+ * This class loads components into HELIO 
+ * @author Andrea Cimmino
+ * @author Juan Cano Benito
+ */
+
 class ComponentsLoader<C> {
 
 	 public C loadClass(String jar, String classpath, Class<C> parentClass) throws Exception {
@@ -13,14 +19,25 @@ class ComponentsLoader<C> {
 		   return loadFromCode(classpath, parentClass);
 	   if( (jar.startsWith(".") || jar.startsWith("/")) && !jar.startsWith("http")) {
 		   // load from file
-			instance = loadFromFile(new File(jar),  classpath, parentClass);
+			instance = loadFromFile(new File(jar),  classpath, parentClass, false);
 	   }else if(jar.startsWith("htt")){
 		   instance = loadFromURL(new URL(jar),  classpath, parentClass);
+	   }else if(isWindows() && Character.isUpperCase(jar.charAt(0))){
+		   // load from file
+			instance = loadFromFile(new File(jar),  classpath, parentClass, true);
 	   }else {
 		   throw new Exception("jar is provided by an unsuported protocol, currently available file or http(s)");
 	   }
 		return instance;
 	}
+	 
+	 /**
+	  * Check if the OS is Windows (any version)
+	  * @return true if the OS is Windows
+	  */
+	 public static boolean isWindows() {
+		 return System.getProperty("os.name").startsWith("Windows");
+	 }
 
 	 private C loadFromURL(URL jar, String classpath, Class<C> parentClass) throws ClassNotFoundException  {
 			C newInstance  = null;
@@ -43,11 +60,14 @@ class ComponentsLoader<C> {
 			return newInstance;
 		}
 
-	private C loadFromFile(File jar, String classpath, Class<C> parentClass) throws ClassNotFoundException  {
+	private C loadFromFile(File jar, String classpath, Class<C> parentClass, boolean isWindows) throws ClassNotFoundException  {
 		C newInstance  = null;
+		String fileURL = "file://";
+		if(isWindows)
+			fileURL = "file:///";
 		try {
 		        ClassLoader loader = URLClassLoader.newInstance(
-		            new URL[] { new URL("file://"+jar.getCanonicalPath()) },
+		            new URL[] { new URL(fileURL+jar.getCanonicalPath()) },
 		            getClass().getClassLoader()
 		        );
 		       Class<?> clazz = Class.forName(classpath, true, loader);


### PR DESCRIPTION
This change allows loading local components in Windows.

The first step is to check if the OS is windows.

The second step is (assuming that the user put a correct path, i.e. put the first letter, which indicates the HDD unit, in uppercase), changing one string from "loadFromFile". In other OS is "file://" meanwhile in Windows is "file:///".